### PR TITLE
add second query to transaction to show theory of what is going on

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -91,6 +91,7 @@ async function read(mode: ReadMode) {
             where: { name: "Python" },
             include: { tail: true },
           }),
+          prisma.$executeRaw`SELECT 1`
         ],
         {
           isolationLevel: "RepeatableRead",


### PR DESCRIPTION
This adds a second query to the transaction, showing that then the reads are properly wrapped in a transaction.